### PR TITLE
Rename for fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,19 @@
-# require-in-the-middle
+# @newrelic/ritm
 
 Hook into the Node.js `require` function. This allows you to modify
 modules on-the-fly as they are being required.
 
-[![npm](https://img.shields.io/npm/v/require-in-the-middle.svg)](https://www.npmjs.com/package/require-in-the-middle)
-[![Test status](https://github.com/elastic/require-in-the-middle/workflows/Test/badge.svg)](https://github.com/elastic/require-in-the-middle/actions)
-
-
 ## Installation
 
 ```
-npm install require-in-the-middle --save
+npm install @newrelic/ritm --save
 ```
 
 ## Usage
 
 ```js
 const path = require('path')
-const { Hook } = require('require-in-the-middle')
+const { Hook } = require('@newrelic/ritm')
 
 // Hook into the express and mongodb module
 new Hook(['express', 'mongodb'], function (exports, name, basedir) {
@@ -35,7 +31,7 @@ new Hook(['express', 'mongodb'], function (exports, name, basedir) {
 
 ## API
 
-The require-in-the-middle module exposes a single function:
+The `@newrelic/ritm` module exposes a single function:
 
 ### `hook = new Hook([modules][, options], onrequire)`
 

--- a/index.js
+++ b/index.js
@@ -3,12 +3,12 @@
 const path = require('path')
 const Module = require('module')
 const resolve = require('resolve')
-const debug = require('debug')('require-in-the-middle')
+const debug = require('debug')('ritm')
 const moduleDetailsFromPath = require('module-details-from-path')
 
 // Using the default export is discouraged, but kept for backward compatibility.
 // Use this instead:
-//    const { Hook } = require('require-in-the-middle')
+//    const { Hook } = require('@newrelic/ritm')
 module.exports = Hook
 module.exports.Hook = Hook
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "require-in-the-middle",
+  "name": "@newrelic/ritm",
   "version": "7.2.0",
   "description": "Module to hook into the Node.js require function",
   "main": "index.js",
@@ -29,7 +29,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/elastic/require-in-the-middle.git"
+    "url": "git+https://github.com/newrelic-forks/require-in-the-middle.git"
   },
   "keywords": [
     "require",
@@ -49,9 +49,9 @@
   "author": "Thomas Watson Steen <w@tson.dk> (https://twitter.com/wa7son)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/elastic/require-in-the-middle/issues"
+    "url": "https://github.com/newrelic-forks/require-in-the-middle/issues"
   },
-  "homepage": "https://github.com/elastic/require-in-the-middle#readme",
+  "homepage": "https://github.com/newrelic-forks/require-in-the-middle#readme",
   "engines": {
     "node": ">=8.6.0"
   }


### PR DESCRIPTION
Update all `require-in-the-middle` references to `@newrelic/ritm`.